### PR TITLE
Fixed name of charm in docstring

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charm the service."""
+"""Traefik Route k8s charm."""
 
 import logging
 from dataclasses import dataclass


### PR DESCRIPTION
This is a very minor change, that adds the name of the charm on the charm's docstring.