### PR TITLE
Forward the external_host through TraefikRoute

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -76,8 +76,8 @@ import logging
 from typing import Optional
 
 import yaml
-from ops.charm import CharmBase, RelationEvent, CharmEvents
-from ops.framework import EventSource, Object
+from ops.charm import CharmBase, CharmEvents, RelationEvent
+from ops.framework import EventSource, Object, StoredState
 from ops.model import Relation
 
 # The unique Charmhub library identifier, never change it
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 log = logging.getLogger(__name__)
 
@@ -111,11 +111,13 @@ class TraefikRouteRequirerReadyEvent(RelationEvent):
 
 class TraefikRouteRequirerEvents(CharmEvents):
     """Container for TraefikRouteRequirer events."""
+
     ready = EventSource(TraefikRouteRequirerReadyEvent)
 
 
 class TraefikRouteProviderEvents(CharmEvents):
     """Container for TraefikRouteProvider events."""
+
     ready = EventSource(TraefikRouteProviderReadyEvent)
 
 
@@ -129,9 +131,11 @@ class TraefikRouteProvider(Object):
     is there.
     The TraefikRouteProvider provides api to do this easily.
     """
-    on = TraefikRouteProviderEvents()
 
-    def __init__(self, charm: CharmBase, relation_name: str = 'traefik-route'):
+    on = TraefikRouteProviderEvents()
+    _stored = StoredState()
+
+    def __init__(self, charm: CharmBase, relation_name: str = "traefik-route"):
         """Constructor for TraefikRouteProvider.
 
         Args:
@@ -140,25 +144,42 @@ class TraefikRouteProvider(Object):
                 (defaults to "traefik-route").
         """
         super().__init__(charm, relation_name)
+        self._stored.set_default(external_host=None)
+
         self.charm = charm
-        self.framework.observe(self.charm.on[relation_name].relation_changed,
-                               self._on_relation_changed)
+        self._relation_name = relation_name
+
+        if self._stored.external_host != charm.external_host:
+            self._stored.external_host = charm.external_host
+            self._update_requirers_with_external_host()
+
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self._on_relation_changed
+        )
 
     def _on_relation_changed(self, event: RelationEvent):
         if self.is_ready(event.relation):
             # todo check data is valid here?
             self.on.ready.emit(event.relation)
 
+    def _update_requirers_with_external_host(self):
+        """Ensure that requirers know the external host for Traefik."""
+        if not self.charm.unit.is_leader():
+            return
+
+        for relation in self.charm.model.relations[self._relation_name]:
+            relation.data[self.charm.app]["external_host"] = self._stored.external_host
+
     @staticmethod
     def is_ready(relation: Relation) -> bool:
         """Whether TraefikRoute is ready on this relation: i.e. the remote app shared the config."""
-        return 'config' in relation.data[relation.app]
+        return "config" in relation.data[relation.app]
 
     @staticmethod
     def get_config(relation: Relation) -> Optional[str]:
         """Retrieve the config published by the remote application."""
         # todo validate this config
-        return relation.data[relation.app].get('config')
+        return relation.data[relation.app].get("config")
 
 
 class TraefikRouteRequirer(Object):
@@ -174,13 +195,32 @@ class TraefikRouteRequirer(Object):
     The TraefikRouteRequirer provides api to store this config in the
     application databag.
     """
-    on = TraefikRouteRequirerEvents()
 
-    def __init__(self, charm: CharmBase, relation: Relation,
-                 relation_name: str = 'traefik-route'):
+    on = TraefikRouteRequirerEvents()
+    _stored = StoredState()
+
+    def __init__(self, charm: CharmBase, relation: Relation, relation_name: str = "traefik-route"):
         super(TraefikRouteRequirer, self).__init__(charm, relation_name)
+        self._stored.set_default(external_host=None)
+
         self._charm = charm
         self._relation = relation
+
+        self.framework.observe(
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
+        )
+
+    @property
+    def external_host(self) -> str:
+        """Return the external host set by Traefik, if any."""
+        return self._stored.external_host or ""
+
+    def _on_relation_changed(self, event: RelationEvent) -> None:
+        """Update StoredState with external_host and other information from Traefik."""
+        if self._charm.unit.is_leader():
+            external_host = event.relation.data[event.app].get("external_host", "")
+            self._stored.external_host = external_host or self._stored.external_host
+            self.on.ready.emit(event.relation)
 
     def is_ready(self) -> bool:
         """Is the TraefikRouteRequirer ready to submit data to Traefik?"""
@@ -198,4 +238,4 @@ class TraefikRouteRequirer(Object):
         app_databag = self._relation.data[self._charm.app]
 
         # Traefik thrives on yaml, feels pointless to talk json to Route
-        app_databag['config'] = yaml.safe_dump(config)
+        app_databag["config"] = yaml.safe_dump(config)

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -135,7 +135,9 @@ class TraefikRouteProvider(Object):
     on = TraefikRouteProviderEvents()
     _stored = StoredState()
 
-    def __init__(self, charm: CharmBase, relation_name: str = "traefik-route"):
+    def __init__(
+        self, charm: CharmBase, relation_name: str = "traefik-route", external_host: str = ""
+    ):
         """Constructor for TraefikRouteProvider.
 
         Args:
@@ -149,8 +151,8 @@ class TraefikRouteProvider(Object):
         self.charm = charm
         self._relation_name = relation_name
 
-        if self._stored.external_host != charm.external_host:
-            self._stored.external_host = charm.external_host
+        if self._stored.external_host != external_host:
+            self._stored.external_host = external_host
             self._update_requirers_with_external_host()
 
         self.framework.observe(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 ops >= 1.2.0
 Jinja2==3.0.3
+typing
+typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ops >= 1.2.0
 Jinja2==3.0.3
-typing
 typing_extensions

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,8 +7,7 @@ from os import unlink
 
 import pytest
 import pytest_asyncio
-import websockets
-from pytest_operator.plugin import OpsTest, check_deps
+from pytest_operator.plugin import OpsTest
 
 TRAEFIK_MOCK_NAME = "traefik-mock"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -51,21 +51,3 @@ async def traefik_mock_charm(ops_test: OpsTest):
 @pytest_asyncio.fixture
 async def ingress_requirer_mock_charm(ops_test: OpsTest):
     return await ops_test.build_charm("./tests/integration/ingress-requirer-mock")
-
-
-@pytest.fixture(scope="module")
-@pytest.mark.asyncio
-async def ops_test(request, tmp_path_factory):
-    check_deps("juju", "charmcraft")
-    ops_test = OpsTest(request, tmp_path_factory)
-    await ops_test._setup_model()
-    OpsTest._instance = ops_test
-    yield ops_test
-    OpsTest._instance = None
-
-    # FIXME: this is necessary because (for some reason) ops_test raises.
-    #  cf: https://github.com/charmed-kubernetes/pytest-operator/issues/71
-    try:
-        await ops_test._cleanup_models()
-    except websockets.exceptions.ConnectionClosed:
-        print("ignored a websockets.exceptions.ConnectionClosed error")

--- a/tests/integration/ingress-requirer-mock/requirements.txt
+++ b/tests/integration/ingress-requirer-mock/requirements.txt
@@ -1,1 +1,3 @@
 ops >= 1.4.0
+typing
+typing_extensions == 4.1.1

--- a/tests/integration/ingress-requirer-mock/requirements.txt
+++ b/tests/integration/ingress-requirer-mock/requirements.txt
@@ -1,3 +1,2 @@
 ops >= 1.4.0
-typing
-typing_extensions == 4.1.1
+typing_extensions

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -44,7 +44,7 @@ async def fast_forward(ops_test, interval: str = "10s"):
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, traefik_route_charm):
-    await ops_test.model.deploy(traefik_route_charm, application_name=APP_NAME)
+    await ops_test.model.deploy(traefik_route_charm, application_name=APP_NAME, series="bionic")
 
 
 async def test_unit_blocked_on_deploy(ops_test: OpsTest):
@@ -55,13 +55,15 @@ async def test_unit_blocked_on_deploy(ops_test: OpsTest):
 
 # both mock charms should start as blocked until they're related
 async def test_deploy_traefik_mock(ops_test: OpsTest, traefik_mock_charm):
-    await ops_test.model.deploy(traefik_mock_charm, application_name=TRAEFIK_MOCK_NAME)
+    await ops_test.model.deploy(
+        traefik_mock_charm, application_name=TRAEFIK_MOCK_NAME, series="bionic"
+    )
     await ops_test.model.wait_for_idle([TRAEFIK_MOCK_NAME], status="blocked")
 
 
 async def test_deploy_ingress_requirer_mock(ops_test: OpsTest, ingress_requirer_mock_charm):
     await ops_test.model.deploy(
-        ingress_requirer_mock_charm, application_name=INGRESS_REQUIRER_MOCK_NAME
+        ingress_requirer_mock_charm, application_name=INGRESS_REQUIRER_MOCK_NAME, series="bionic"
     )
     await ops_test.model.wait_for_idle([INGRESS_REQUIRER_MOCK_NAME], status="blocked")
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -44,7 +44,7 @@ async def fast_forward(ops_test, interval: str = "10s"):
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, traefik_route_charm):
-    await ops_test.model.deploy(traefik_route_charm, application_name=APP_NAME, series="bionic")
+    await ops_test.model.deploy(traefik_route_charm, application_name=APP_NAME, series="focal")
 
 
 async def test_unit_blocked_on_deploy(ops_test: OpsTest):
@@ -56,14 +56,14 @@ async def test_unit_blocked_on_deploy(ops_test: OpsTest):
 # both mock charms should start as blocked until they're related
 async def test_deploy_traefik_mock(ops_test: OpsTest, traefik_mock_charm):
     await ops_test.model.deploy(
-        traefik_mock_charm, application_name=TRAEFIK_MOCK_NAME, series="bionic"
+        traefik_mock_charm, application_name=TRAEFIK_MOCK_NAME, series="focal"
     )
     await ops_test.model.wait_for_idle([TRAEFIK_MOCK_NAME], status="blocked")
 
 
 async def test_deploy_ingress_requirer_mock(ops_test: OpsTest, ingress_requirer_mock_charm):
     await ops_test.model.deploy(
-        ingress_requirer_mock_charm, application_name=INGRESS_REQUIRER_MOCK_NAME, series="bionic"
+        ingress_requirer_mock_charm, application_name=INGRESS_REQUIRER_MOCK_NAME, series="focal"
     )
     await ops_test.model.wait_for_idle([INGRESS_REQUIRER_MOCK_NAME], status="blocked")
 

--- a/tests/integration/traefik-mock/requirements.txt
+++ b/tests/integration/traefik-mock/requirements.txt
@@ -1,1 +1,3 @@
 ops >= 1.4.0
+typing
+typing_extensions == 4.1.1

--- a/tests/integration/traefik-mock/requirements.txt
+++ b/tests/integration/traefik-mock/requirements.txt
@@ -1,3 +1,2 @@
 ops >= 1.4.0
-typing
-typing_extensions == 4.1.1
+typing_extensions

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -82,5 +82,8 @@ def reinstantiate_charm(harness: Harness):
     harness.framework._forget(charm.ingress_per_unit.on)
     harness.framework._forget(charm.traefik_route)
     harness.framework._forget(charm.traefik_route.on)
+    harness.framework._objects.pop(
+        "TraefikRouteK8SCharm/TraefikRouteRequirer[traefik-route]/StoredStateData[_stored]", None
+    )
     harness._charm = None
     harness.begin()

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = lint, unit
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
 lib_path = {toxinidir}/lib/charms/traefik_route_k8s
-all_path = {[vars]src_path} {[vars]tst_path} 
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 setenv =
@@ -68,6 +68,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    asyncstdlib
     pytest
     juju
     pytest-operator


### PR DESCRIPTION
Previously, `TraefikRouteProvider` did not send any information back to `TraefikRouteRequirer`, including the `external_host` Traefik may be bound to, so the `Requirer` has no way of knowing (inside the Juju data/permissions model) what external address it could be reachable on.

Now, `TraefikRouteProvider` keeps the "known" `external_host` in `StoredState`, and checks `traefik-k8s`'s `external_host` property at instantiation. If it differs, it writes this to relation data, and an event is fired from the `Provider`, so the charm which has provided the configuration can read an `external_host` property.