### PR TITLE
fix for traefik-route error when stored.external_hostname==None

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -148,7 +148,7 @@ class TraefikRouteProvider(Object):
         super().__init__(charm, relation_name)
         self._stored.set_default(external_host=None)
 
-        self.charm = charm
+        self._charm = charm
         self._relation_name = relation_name
 
         if self._stored.external_host != external_host:
@@ -157,8 +157,30 @@ class TraefikRouteProvider(Object):
             self._update_requirers_with_external_host()
 
         self.framework.observe(
-            self.charm.on[relation_name].relation_changed, self._on_relation_changed
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
         )
+
+    @property
+    def external_host(self) -> str:
+        """Return the external host set by Traefik, if any."""
+        self._update_stored_external_host()
+        return self._stored.external_host or ""
+
+    def _update_stored_external_host(self) -> None:
+        """Ensure that the stored host is up to date.
+
+        This is split out into a separate method since, in the case of multi-unit deployments,
+        removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on
+        app data ensures that only the previous leader will know what it is. Separating it
+        allows for re-use both when the property is called and if the relation changes, so a
+        leader change where the new leader checks the property will do the right thing."""
+        if self._charm.unit.is_leader():
+            for relation in self._charm.model.relations[self._relation_name]:
+                if not relation.app:
+                    self._stored.external_host = ""
+                    return
+                external_host = relation.data[relation.app].get("external_host", "")
+                self._stored.external_host = external_host or self._stored.external_host
 
     def _on_relation_changed(self, event: RelationEvent):
         if self.is_ready(event.relation):
@@ -168,11 +190,11 @@ class TraefikRouteProvider(Object):
 
     def _update_requirers_with_external_host(self):
         """Ensure that requirers know the external host for Traefik."""
-        if not self.charm.unit.is_leader():
+        if not self._charm.unit.is_leader():
             return
 
-        for relation in self.charm.model.relations[self._relation_name]:
-            relation.data[self.charm.app]["external_host"] = self._stored.external_host
+        for relation in self._charm.model.relations[self._relation_name]:
+            relation.data[self._charm.app]["external_host"] = self.external_host
 
     @staticmethod
     def is_ready(relation: Relation) -> bool:

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 2
 
 log = logging.getLogger(__name__)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,8 +22,9 @@ APP_NAME = METADATA["name"]
 MOCK_ROOT_URL_TEMPLATE = "http://{{juju_unit}}.foo/bar/"
 
 
-async def assert_status_reached(ops_test, status: str, apps=(APP_NAME,), raise_on_blocked=True,
-                                timeout=180):
+async def assert_status_reached(
+    ops_test, status: str, apps=(APP_NAME,), raise_on_blocked=True, timeout=180
+):
     print(f"waiting for {apps} to reach {status}...")
     assert not isinstance(apps, str)
     apps = list(apps)
@@ -62,14 +63,14 @@ async def test_deploy_traefik_mock(ops_test: OpsTest, traefik_mock_charm):
     await ops_test.model.deploy(
         traefik_mock_charm, application_name=TRAEFIK_MOCK_NAME, series="focal"
     )
-    await assert_status_reached(ops_test, "blocked", apps=(TRAEFIK_MOCK_NAME, ))
+    await assert_status_reached(ops_test, "blocked", apps=(TRAEFIK_MOCK_NAME,))
 
 
 async def test_deploy_ingress_requirer_mock(ops_test: OpsTest, ingress_requirer_mock_charm):
     await ops_test.model.deploy(
         ingress_requirer_mock_charm, application_name=INGRESS_REQUIRER_MOCK_NAME, series="focal"
     )
-    await assert_status_reached(ops_test, "blocked", apps=(INGRESS_REQUIRER_MOCK_NAME, ))
+    await assert_status_reached(ops_test, "blocked", apps=(INGRESS_REQUIRER_MOCK_NAME,))
 
 
 async def test_unit_blocked_after_config(ops_test: OpsTest):
@@ -114,7 +115,7 @@ async def test_relations(ops_test: OpsTest):
             # However, route was blocked moments ago, so it might still be blocked by the time
             # we start awaiting active; so we trust it will eventually unblock itself.
             raise_on_blocked=False,
-            timeout=5000
+            timeout=5000,
         )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,6 +5,7 @@ import asyncio
 import contextlib
 import logging
 import textwrap
+from asyncio import sleep
 from pathlib import Path
 
 import pytest
@@ -21,13 +22,16 @@ APP_NAME = METADATA["name"]
 MOCK_ROOT_URL_TEMPLATE = "http://{{juju_unit}}.foo/bar/"
 
 
-async def assert_status_reached(ops_test, status: str, apps=(APP_NAME,), raise_on_blocked=True):
+async def assert_status_reached(ops_test, status: str, apps=(APP_NAME,), raise_on_blocked=True,
+                                timeout=180):
     print(f"waiting for {apps} to reach {status}...")
+    assert not isinstance(apps, str)
+    apps = list(apps)
 
     await ops_test.model.wait_for_idle(
         apps=apps,
         status=status,
-        timeout=180,
+        timeout=timeout,
         raise_on_blocked=False if status == "blocked" else raise_on_blocked,
     )
     for app in apps:
@@ -50,7 +54,7 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_route_charm):
 async def test_unit_blocked_on_deploy(ops_test: OpsTest):
     async with fast_forward(ops_test):
         # Route will go to blocked until configured
-        await assert_status_reached(ops_test, "blocked")
+        await assert_status_reached(ops_test, "blocked", timeout=5000)
 
 
 # both mock charms should start as blocked until they're related
@@ -58,20 +62,22 @@ async def test_deploy_traefik_mock(ops_test: OpsTest, traefik_mock_charm):
     await ops_test.model.deploy(
         traefik_mock_charm, application_name=TRAEFIK_MOCK_NAME, series="focal"
     )
-    await ops_test.model.wait_for_idle([TRAEFIK_MOCK_NAME], status="blocked")
+    await assert_status_reached(ops_test, "blocked", apps=(TRAEFIK_MOCK_NAME, ))
 
 
 async def test_deploy_ingress_requirer_mock(ops_test: OpsTest, ingress_requirer_mock_charm):
     await ops_test.model.deploy(
         ingress_requirer_mock_charm, application_name=INGRESS_REQUIRER_MOCK_NAME, series="focal"
     )
-    await ops_test.model.wait_for_idle([INGRESS_REQUIRER_MOCK_NAME], status="blocked")
+    await assert_status_reached(ops_test, "blocked", apps=(INGRESS_REQUIRER_MOCK_NAME, ))
 
 
 async def test_unit_blocked_after_config(ops_test: OpsTest):
     # configure
     app: Application = ops_test.model.applications.get(APP_NAME)
     await app.set_config({"root_url": "http://foo/"})
+
+    await sleep(5)  # give it some time to process the relation-changed...
 
     # now we're blocked still, because we have no relations.
     async with fast_forward(ops_test):
@@ -87,8 +93,6 @@ async def test_relations(ops_test: OpsTest):
         ops_test.model.add_relation(
             f"{TRAEFIK_MOCK_NAME}:traefik-route", f"{APP_NAME}:traefik-route"
         ),
-        # prometheus' endpoint is called 'ingress',
-        # but our mock charm calls it 'ingress-per-unit'
         ops_test.model.add_relation(
             f"{INGRESS_REQUIRER_MOCK_NAME}:ingress-per-unit", f"{APP_NAME}:ingress-per-unit"
         ),
@@ -110,6 +114,7 @@ async def test_relations(ops_test: OpsTest):
             # However, route was blocked moments ago, so it might still be blocked by the time
             # we start awaiting active; so we trust it will eventually unblock itself.
             raise_on_blocked=False,
+            timeout=5000
         )
 
 


### PR DESCRIPTION
[Fixes #](https://github.com/canonical/traefik-route-k8s-operator/issues/20)