### PR TITLE
Emit revoked event on relation broken

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -105,7 +105,7 @@ class TraefikRouteProviderReadyEvent(RelationEvent):
     """Event emitted when Traefik is ready to provide ingress for a routed unit."""
 
 
-class TraefikRouteProviderRevokedEvent(RelationEvent):
+class TraefikRouteProviderDataRemovedEvent(RelationEvent):
     """Event emitted when a routed ingress relation is removed."""
 
 
@@ -123,7 +123,7 @@ class TraefikRouteProviderEvents(CharmEvents):
     """Container for TraefikRouteProvider events."""
 
     ready = EventSource(TraefikRouteProviderReadyEvent)  # TODO rename to data_provided in v1
-    data_removed = EventSource(TraefikRouteProviderRevokedEvent)
+    data_removed = EventSource(TraefikRouteProviderDataRemovedEvent)
 
 
 class TraefikRouteProvider(Object):

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -117,13 +117,13 @@ class TraefikRouteRequirerEvents(CharmEvents):
     """Container for TraefikRouteRequirer events."""
 
     ready = EventSource(TraefikRouteRequirerReadyEvent)
-    revoked = EventSource(TraefikRouteProviderRevokedEvent)
 
 
 class TraefikRouteProviderEvents(CharmEvents):
     """Container for TraefikRouteProvider events."""
 
-    ready = EventSource(TraefikRouteProviderReadyEvent)
+    ready = EventSource(TraefikRouteProviderReadyEvent)  # TODO rename to data_provided in v1
+    data_removed = EventSource(TraefikRouteProviderRevokedEvent)
 
 
 class TraefikRouteProvider(Object):
@@ -197,7 +197,7 @@ class TraefikRouteProvider(Object):
             self.on.ready.emit(event.relation)
 
     def _on_relation_broken(self, event: RelationEvent):
-        self.on.revoked.emit(event.relation)
+        self.on.data_removed.emit(event.relation)
 
     def _update_requirers_with_external_host(self):
         """Ensure that requirers know the external host for Traefik."""

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import textwrap
+import unittest
+
+import ops
+from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteProvider, TraefikRouteProviderReadyEvent, TraefikRouteProviderDataRemovedEvent
+from ops.charm import CharmBase
+from ops.framework import StoredState
+from ops.testing import Harness
+from charms.harness_extensions.v0.capture_events import capture
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+
+
+class DummyProviderCharm(CharmBase):
+    """Mimic functionality needed to test the provider."""
+
+    # define custom metadata - without this the harness would parse the metadata.yaml in this repo,
+    # which would result in expressions like self.harness.model.app.name to return
+    # "traefik-route-k8s", which is not what we want in a provider test
+    metadata_yaml = textwrap.dedent(
+        """
+        name: DummyProviderCharm
+        provides:
+          traefik-route:
+            interface: traefik_route
+        """
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+        # relation name must match metadata
+        self.traefik_route = TraefikRouteProvider(self, relation_name="traefik-route")
+
+
+class TestProviderEvents(unittest.TestCase):
+    def setUp(self):
+        self.harness = Harness(DummyProviderCharm, meta=DummyProviderCharm.metadata_yaml)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+    def _relate_to_consumer(self, name: str = "consumer-app") -> int:
+        """Create relation between 'this app' (e.g. traefik) and a remote app (traefik-route)."""
+        rel_id = self.harness.add_relation(relation_name="traefik-route", remote_app=name)
+        self.harness.add_relation_unit(rel_id, f"{name}/0")
+        return rel_id
+
+    def test_custom_event_emitted_on_join(self):
+        app = "trfk-rt"
+        rel_id = self._relate_to_consumer(app)
+        with capture(self.harness.charm, TraefikRouteProviderReadyEvent):
+            self.harness.update_relation_data(rel_id, app, {"config": "blob"})
+
+    def test_custom_event_emitted_on_depart(self):
+        rel_id = self._relate_to_consumer()
+        with capture(self.harness.charm, TraefikRouteProviderDataRemovedEvent):
+            self.harness.remove_relation(rel_id)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -6,11 +6,14 @@ import textwrap
 import unittest
 
 import ops
-from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteProvider, TraefikRouteProviderReadyEvent, TraefikRouteProviderDataRemovedEvent
-from ops.charm import CharmBase
-from ops.framework import StoredState
-from ops.testing import Harness
 from charms.harness_extensions.v0.capture_events import capture
+from charms.traefik_route_k8s.v0.traefik_route import (
+    TraefikRouteProvider,
+    TraefikRouteProviderDataRemovedEvent,
+    TraefikRouteProviderReadyEvent,
+)
+from ops.charm import CharmBase
+from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -49,13 +49,13 @@ class TestProviderEvents(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, f"{name}/0")
         return rel_id
 
-    def test_custom_event_emitted_on_join(self):
+    def test_custom_event_emitted_when_related(self):
         app = "trfk-rt"
         rel_id = self._relate_to_consumer(app)
         with capture(self.harness.charm, TraefikRouteProviderReadyEvent):
             self.harness.update_relation_data(rel_id, app, {"config": "blob"})
 
-    def test_custom_event_emitted_on_depart(self):
+    def test_custom_event_emitted_when_relation_removed(self):
         rel_id = self._relate_to_consumer()
         with capture(self.harness.charm, TraefikRouteProviderDataRemovedEvent):
             self.harness.remove_relation(rel_id)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -5,7 +5,6 @@
 import textwrap
 import unittest
 
-import ops
 from charms.harness_extensions.v0.capture_events import capture
 from charms.traefik_route_k8s.v0.traefik_route import (
     TraefikRouteProvider,
@@ -14,8 +13,6 @@ from charms.traefik_route_k8s.v0.traefik_route import (
 )
 from ops.charm import CharmBase
 from ops.testing import Harness
-
-ops.testing.SIMULATE_CAN_CONNECT = True
 
 
 class DummyProviderCharm(CharmBase):


### PR DESCRIPTION
When grafana is re-related to traefik, traefik doesn't wipe the old yaml.

In the following example, the traefik container has yaml files for relations 5 and 8, even though relation 5 doesn't exist anymore:

```
$ jshu traefik/0 | grep "relation-id"
  - relation-id: 3
  - relation-id: 4
  - relation-id: 7
  - relation-id: 8

$ jsshc traefik traefik/0 ls /opt/traefik/juju
certificates.yaml
juju_ingress_ingress-per-unit_4_prometheus.yaml
juju_ingress_ingress_3_alertmanager.yaml
juju_ingress_traefik-route_5_grafana.yaml
juju_ingress_traefik-route_8_grafana.yaml
```

And traefik gently complains:
```
$ k logs -c traefik pods/traefik-0 -n test-traefik-deployed-after-metallb-zk3n

2023-01-05T19:31:15.221Z [traefik] time="2023-01-05T19:31:15Z" level=warning msg="HTTP router already configured, skipping" routerName=juju-test-traefik-deployed-after-metallb-zk3n-grafana-router filename=juju_ingress_traefik-route_8_grafana.yaml providerName=file
2023-01-05T19:31:15.221Z [traefik] time="2023-01-05T19:31:15Z" level=warning msg="HTTP service already configured, skipping" providerName=file filename=juju_ingress_traefik-route_8_grafana.yaml serviceName=juju-test-traefik-deployed-after-metallb-zk3n-grafana-service
```

This PR adds a `revoked` event so that it could be handled similarly to ipa and ipu from within traefik:

```python
# lib
observe(rel_events.relation_broken, self._handle_relation_broken)
```
```python
    # lib
    def _handle_relation_broken(self, event):
        self.on.data_removed.emit(event.relation)
```
```python
# traefik charm
observe(ipa_events.data_removed, self._handle_ingress_data_removed)
```
```diff
    # traefik charm
    def _handle_ingress_data_removed(self, event: RelationEvent):
        """A unit has removed the data we need to provide ingress."""
-       # if this is because the relation is gone, we don't need to do anything
-        if isinstance(event, RelationBrokenEvent):
-           return
        self._wipe_ingress_for_relation(event.relation)
```

Side note: currently it seems that `_wipe_ingress_for_relation` never takes place on relation removal. Seems like this is a mistake.