### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,26 +18,22 @@ asyncio_mode = "auto"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 [tool.mypy]
 pretty = true
 python_version = 3.8

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,6 @@ from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Relation, Unit
-
 from types_ import TraefikConfig, UnitConfig
 
 logger = logging.getLogger(__name__)
@@ -259,7 +258,7 @@ class TraefikRouteK8SCharm(CharmBase):
         if not ipu_relation:
             self.unit.status = BlockedStatus("Awaiting to be related via ingress-per-unit.")
             return False
-        elif not self.ingress_per_unit.is_ready(ipu_relation):
+        if not self.ingress_per_unit.is_ready(ipu_relation):
             self.unit.status = BlockedStatus("ingress-per-unit relation is not ready.")
             return False
 
@@ -286,6 +285,7 @@ class TraefikRouteK8SCharm(CharmBase):
         )
         self._update()
         self.unit.status = ActiveStatus()
+        return None
 
     def _config_for_unit(self, unit_data: RequirerData) -> RouteConfig:
         """Get the _RouteConfig for the provided `unit_data`."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,10 +4,9 @@
 import json
 
 import pytest as pytest
+from charm import TraefikRouteK8SCharm
 from ops import framework, storage
 from ops.testing import Harness
-
-from charm import TraefikRouteK8SCharm
 
 MODEL_NAME = "model"
 REMOTE_APP_NAME = "remote"  # the app requesting ingress

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,12 +5,12 @@ from unittest.mock import Mock
 
 import pytest
 import yaml
+from charm import TraefikRouteK8SCharm
 from charms.harness_extensions.v0.capture_events import capture
 from charms.traefik_k8s.v1.ingress_per_unit import IngressDataReadyEvent
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
-from charm import TraefikRouteK8SCharm
 from tests.unit.conftest import (
     REMOTE_UNIT_NAME,
     SAMPLE_INGRESS_DATA,

--- a/tox.ini
+++ b/tox.ini
@@ -26,31 +26,23 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     # uncomment the following line if this charm owns a lib
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* \
       --skip .mypy_cache --skip icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib,unit,integration}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being two new rules being ignored (which weren't checked before anyway): 
* `N818: Exception name should be named with an Error suffix`, which I excluded due to the big refactoring required for it;
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.