### PR TITLE
Add scheme to TraefikRouteProvider

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -209,9 +209,9 @@ class TraefikRouteProvider(Object):
                 self._stored.scheme = ""
                 return
             external_host = relation.data[relation.app].get("external_host", "")
-            self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+            self._stored.external_host = external_host or self._stored.external_host
             scheme = relation.data[relation.app].get("scheme", "")
-            self._stored.scheme = scheme or self._stored.scheme  # type: ignore
+            self._stored.scheme = scheme or self._stored.scheme
 
     def _on_relation_changed(self, event: RelationEvent):
         if self.is_ready(event.relation):
@@ -317,9 +317,9 @@ class TraefikRouteRequirer(Object):
                     self._stored.scheme = ""
                     return
                 external_host = relation.data[relation.app].get("external_host", "")
-                self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+                self._stored.external_host = external_host or self._stored.external_host
                 scheme = relation.data[relation.app].get("scheme", "")
-                self._stored.scheme = scheme or self._stored.scheme  # type: ignore
+                self._stored.scheme = scheme or self._stored.scheme
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
         """Update StoredState with external_host and other information from Traefik."""

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -192,7 +192,7 @@ class TraefikRouteProvider(Object):
         return list(self._charm.model.relations[self._relation_name])
 
     def _update_stored(self) -> None:
-        """Ensure that the stored host is up-to-date.
+        """Ensure that the stored data is up-to-date.
 
         This is split out into a separate method since, in the case of multi-unit deployments,
         removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit
+envlist = lint, static-{charm,lib}, unit
 
 [vars]
 src_path = {toxinidir}/src/
@@ -60,7 +60,7 @@ deps =
 commands =
   charm: mypy {[vars]src_path} {posargs}
   lib: mypy --python-version 3.8 {[vars]lib_path} {posargs}
-  lib: /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do if ! git diff $m | grep -q "+LIBPATCH\|+LIBAPI"; then echo "You forgot to bump the version on $m!"; exit 1; fi; done'
+  lib: /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do if ! git diff main $m | grep -q "+LIBPATCH\|+LIBAPI"; then echo "You forgot to bump the version on $m!"; exit 1; fi; done'
   unit: mypy {[vars]tst_path}/unit {posargs}
   integration: mypy {[vars]tst_path}/integration {posargs} \
     --exclude {[vars]tst_path}/integration/ingress-requirer-mock
@@ -76,6 +76,8 @@ commands =
     coverage run --source={[vars]src_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
+
+[testenv:scenario]
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
## Problem
Grafana, which uses traefik_route, is currently unable to tell if the ingress endpoint is http or https.

## Solution
This PR adds a scheme arg, so that traefik could inform over relation data which scheme it is using.

In tandem with:
- https://github.com/canonical/traefik-k8s-operator/pull/234
- https://github.com/canonical/grafana-k8s-operator/pull/257