### PR TITLE
Libpatch 10 of the traefik_route library isn't published

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,4 +10,4 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools]
+    charm-python-packages: [setuptools, markupsafe]

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 log = logging.getLogger(__name__)
 
@@ -243,21 +243,34 @@ class TraefikRouteProvider(Object):
         self._stored.external_host = external_host
         self._stored.scheme = scheme
 
-    @staticmethod
-    def is_ready(relation: Relation) -> bool:
+    def is_ready(self, relation: Relation) -> bool:
         """Whether TraefikRoute is ready on this relation.
 
         Returns True when the remote app shared the config; False otherwise.
         """
-        assert relation.app is not None  # not currently handled anyway
+        if not relation.app or not relation.data[relation.app]:
+            return False
         return "config" in relation.data[relation.app]
 
-    @staticmethod
-    def get_config(relation: Relation) -> Optional[str]:
-        """Retrieve the config published by the remote application."""
-        # TODO: validate this config
-        assert relation.app is not None  # not currently handled anyway
+    def get_config(self, relation: Relation) -> Optional[str]:
+        """Renamed to ``get_dynamic_config``."""
+        log.warning(
+            "``TraefikRouteProvider.get_config`` is deprecated. "
+            "Use ``TraefikRouteProvider.get_dynamic_config`` instead"
+        )
+        return self.get_dynamic_config(relation)
+
+    def get_dynamic_config(self, relation: Relation) -> Optional[str]:
+        """Retrieve the dynamic config published by the remote application."""
+        if not self.is_ready(relation):
+            return None
         return relation.data[relation.app].get("config")
+
+    def get_static_config(self, relation: Relation) -> Optional[str]:
+        """Retrieve the static config published by the remote application."""
+        if not self.is_ready(relation):
+            return None
+        return relation.data[relation.app].get("static")
 
 
 class TraefikRouteRequirer(Object):
@@ -266,6 +279,7 @@ class TraefikRouteRequirer(Object):
     The traefik_route requirer will publish to the application databag an object like:
     {
         'config': <Traefik_config>
+        'static': <Traefik_config>  # optional
     }
 
     NB: TraefikRouteRequirer does no validation; it assumes that the
@@ -344,11 +358,15 @@ class TraefikRouteRequirer(Object):
         """Is the TraefikRouteRequirer ready to submit data to Traefik?"""
         return self._relation is not None
 
-    def submit_to_traefik(self, config):
+    def submit_to_traefik(self, config: dict, static: dict = None):
         """Relay an ingress configuration data structure to traefik.
 
-        This will publish to TraefikRoute's traefik-route relation databag
-        the config traefik needs to route the units behind this charm.
+        This will publish to the traefik-route relation databag
+        a chunk of Traefik dynamic config that the traefik charm on the other end can pick
+        up and apply.
+
+        Use ``static`` if you need to update traefik's **static** configuration.
+        Note that this will force traefik to restart to comply.
         """
         if not self._charm.unit.is_leader():
             raise UnauthorizedError()
@@ -357,3 +375,6 @@ class TraefikRouteRequirer(Object):
 
         # Traefik thrives on yaml, feels pointless to talk json to Route
         app_databag["config"] = yaml.safe_dump(config)
+
+        if static:
+            app_databag["static"] = yaml.safe_dump(static)

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -358,7 +358,7 @@ class TraefikRouteRequirer(Object):
         """Is the TraefikRouteRequirer ready to submit data to Traefik?"""
         return self._relation is not None
 
-    def submit_to_traefik(self, config: dict, static: dict = None):
+    def submit_to_traefik(self, config: dict, static: Optional[dict] = None):
         """Relay an ingress configuration data structure to traefik.
 
         This will publish to the traefik-route relation databag

--- a/src/charm.py
+++ b/src/charm.py
@@ -348,7 +348,7 @@ class TraefikRouteK8SCharm(CharmBase):
         # merge configs?
         config = self._merge_traefik_configs(unit_configs)
         if self.traefik_route.is_ready():
-            self.traefik_route.submit_to_traefik(config=config)
+            self.traefik_route.submit_to_traefik(config=config)  # type: ignore
 
     @staticmethod
     def _generate_traefik_unit_config(route_config: RouteConfig) -> "UnitConfig":


### PR DESCRIPTION
## Issue
Fixes #58 

## Solution
Use lib patch 10 from [tempo](https://github.com/canonical/tempo-coordinator-k8s-operator/blob/main/lib/charms/traefik_route_k8s/v0/traefik_route.py)

drive-by: Add `markupsafe` as charm python package, as its needed by jinj2

## Context
https://github.com/canonical/traefik-k8s-operator/issues/379

