### PR TITLE
Deprecate `traefik_route v0` library

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -2,75 +2,16 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-r"""# Interface Library for traefik_route.
+r"""# [DEPRECATED!] Interface Library for traefik_route.
 
-This library wraps relation endpoints for traefik_route. The requirer of this
-relation is the traefik-route-k8s charm, or any charm capable of providing
-Traefik configuration files. The provider is the traefik-k8s charm, or another
-charm willing to consume Traefik configuration files.
+This is a DEPRECATED version of the traefik_route interface library.
 
-## Getting Started
+It was dropped and no longer maintained by `traefik-route-k8s-operator`, which will soon be archived.
 
-To get started using the library, you just need to fetch the library using `charmcraft`.
+traefik_route v0 is now maintained by `traefik-k8s-operator`.
 
-```shell
-cd some-charm
-charmcraft fetch-lib charms.traefik_route_k8s.v0.traefik_route
-```
+Please import with `charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route`.
 
-To use the library from the provider side (Traefik):
-
-```yaml
-requires:
-    traefik_route:
-        interface: traefik_route
-        limit: 1
-```
-
-```python
-from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteProvider
-
-class TraefikCharm(CharmBase):
-  def __init__(self, *args):
-    # ...
-    self.traefik_route = TraefikRouteProvider(self)
-
-    self.framework.observe(
-        self.traefik_route.on.ready, self._handle_traefik_route_ready
-    )
-
-    def _handle_traefik_route_ready(self, event):
-        config: str = self.traefik_route.get_config(event.relation)  # yaml
-        # use config to configure Traefik
-```
-
-To use the library from the requirer side (TraefikRoute):
-
-```yaml
-requires:
-    traefik-route:
-        interface: traefik_route
-        limit: 1
-        optional: false
-```
-
-```python
-# ...
-from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
-
-class TraefikRouteCharm(CharmBase):
-  def __init__(self, *args):
-    # ...
-    traefik_route = TraefikRouteRequirer(
-        self, self.model.relations.get("traefik-route"),
-        "traefik-route"
-    )
-    if traefik_route.is_ready():
-        traefik_route.submit_to_traefik(
-            config={'my': {'traefik': 'configuration'}}
-        )
-
-```
 """
 import logging
 from typing import Optional
@@ -88,7 +29,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 log = logging.getLogger(__name__)
 
@@ -157,6 +98,12 @@ class TraefikRouteProvider(Object):
             external_host: The external host.
             scheme: The scheme.
         """
+        log.warning(
+            "The ``traefik_route v0`` library is DEPRECATED "
+            "and no longer maintained by ``traefik-route-k8s-operator``. "
+            "``traefik_route v0`` is now maintained by ``traefik-k8s-operator``. "
+            "Please import with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
+        )
         super().__init__(charm, relation_name)
         self._stored.set_default(external_host=None, scheme=None)
 
@@ -292,6 +239,12 @@ class TraefikRouteRequirer(Object):
     _stored = StoredState()
 
     def __init__(self, charm: CharmBase, relation: Relation, relation_name: str = "traefik-route"):
+        log.warning(
+            "The ``traefik_route v0`` library is DEPRECATED "
+            "and no longer maintained by ``traefik-route-k8s-operator``. "
+            "``traefik_route v0`` is now maintained by ``traefik-k8s-operator``. "
+            "Please import with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
+        )
         super(TraefikRouteRequirer, self).__init__(charm, relation_name)
         self._stored.set_default(external_host=None, scheme=None)
 

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -10,7 +10,7 @@ It was dropped and no longer maintained under `traefik-route-k8s-operator`, whic
 
 traefik_route v0 is now maintained under `traefik-k8s-operator`.
 
-Please import with `charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route`.
+Please fetch the new library with `charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route`.
 
 """
 import logging
@@ -102,7 +102,7 @@ class TraefikRouteProvider(Object):
             "The ``traefik_route v0`` library is DEPRECATED "
             "and no longer maintained under ``traefik-route-k8s-operator``. "
             "``traefik_route v0`` is now maintained under ``traefik-k8s-operator``. "
-            "Please import with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
+            "Please fetch the new library with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
         )
         super().__init__(charm, relation_name)
         self._stored.set_default(external_host=None, scheme=None)
@@ -243,7 +243,7 @@ class TraefikRouteRequirer(Object):
             "The ``traefik_route v0`` library is DEPRECATED "
             "and no longer maintained under ``traefik-route-k8s-operator``. "
             "``traefik_route v0`` is now maintained under ``traefik-k8s-operator``. "
-            "Please import with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
+            "Please fetch the new library with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
         )
         super(TraefikRouteRequirer, self).__init__(charm, relation_name)
         self._stored.set_default(external_host=None, scheme=None)

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -6,9 +6,9 @@ r"""# [DEPRECATED!] Interface Library for traefik_route.
 
 This is a DEPRECATED version of the traefik_route interface library.
 
-It was dropped and no longer maintained by `traefik-route-k8s-operator`, which will soon be archived.
+It was dropped and no longer maintained under `traefik-route-k8s-operator`, which will soon be archived.
 
-traefik_route v0 is now maintained by `traefik-k8s-operator`.
+traefik_route v0 is now maintained under `traefik-k8s-operator`.
 
 Please import with `charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route`.
 
@@ -100,8 +100,8 @@ class TraefikRouteProvider(Object):
         """
         log.warning(
             "The ``traefik_route v0`` library is DEPRECATED "
-            "and no longer maintained by ``traefik-route-k8s-operator``. "
-            "``traefik_route v0`` is now maintained by ``traefik-k8s-operator``. "
+            "and no longer maintained under ``traefik-route-k8s-operator``. "
+            "``traefik_route v0`` is now maintained under ``traefik-k8s-operator``. "
             "Please import with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
         )
         super().__init__(charm, relation_name)
@@ -241,8 +241,8 @@ class TraefikRouteRequirer(Object):
     def __init__(self, charm: CharmBase, relation: Relation, relation_name: str = "traefik-route"):
         log.warning(
             "The ``traefik_route v0`` library is DEPRECATED "
-            "and no longer maintained by ``traefik-route-k8s-operator``. "
-            "``traefik_route v0`` is now maintained by ``traefik-k8s-operator``. "
+            "and no longer maintained under ``traefik-route-k8s-operator``. "
+            "``traefik_route v0`` is now maintained under ``traefik-k8s-operator``. "
             "Please import with ``charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route``."
         )
         super(TraefikRouteRequirer, self).__init__(charm, relation_name)


### PR DESCRIPTION
## Issue
Contributes to fixing #55 and https://github.com/canonical/traefik-k8s-operator/issues/379

## Solution
Add deprecation notice that this library is no longer maintained under this repo, but rather under `traefik-k8s-operator`

